### PR TITLE
Update doppler_secrets.py

### DIFF
--- a/plugins/lookup/doppler_secrets.py
+++ b/plugins/lookup/doppler_secrets.py
@@ -141,7 +141,7 @@ class LookupModule(LookupBase):
             self._display.vvv(f"Param {name} not avaible,default to env variable")
             if env_var is None:
                 env_var = f"DOPPLER_{name.upper()}"
-            val = os.environ(env_var)
+            val = os.environ.get(env_var)
             return val
 
     def validate(self, params):


### PR DESCRIPTION
The current implementation of the get_option_with_fallback method uses os.environ as if it were a callable:
```python
  val = os.environ(env_var)  
```
However, os.environ is an instance of _Environ, which behaves like a dictionary and is not callable. Attempting to call it results in a TypeError:

```
TypeError: '_Environ' object is not callable  
```
This error occurs whenever a lookup parameter (e.g., project, config, name, token, url) is not provided directly to the plugin and is supposed to fall back to an environment variable. In those cases, get_option_with_fallback tries to read from the environment and fails with the above exception, preventing the plugin from working as intended.
To correctly retrieve values from the environment, os.environ must be accessed like a mapping (dictionary), not called like a function.